### PR TITLE
Added 24.11 as a stable nixpkgs input and swapped bat to use it

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -142,6 +142,22 @@
         "type": "indirect"
       }
     },
+    "nixpkgs-stable": {
+      "locked": {
+        "lastModified": 1736549401,
+        "narHash": "sha256-ibkQrMHxF/7TqAYcQE+tOnIsSEzXmMegzyBWza6uHKM=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "1dab772dd4a68a7bba5d9460685547ff8e17d899",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-24.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "nixpkgs_2": {
       "locked": {
         "lastModified": 1716330097,
@@ -196,6 +212,7 @@
         "nix-darwin": "nix-darwin",
         "nix-homebrew": "nix-homebrew",
         "nixpkgs": "nixpkgs_3",
+        "nixpkgs-stable": "nixpkgs-stable",
         "rust-overlay": "rust-overlay",
         "zig-overlay": "zig-overlay"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -3,6 +3,7 @@
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    nixpkgs-stable.url = "github:nixos/nixpkgs?ref=nixos-24.11";
     nix-darwin.url = "github:LnL7/nix-darwin";
     nix-darwin.inputs.nixpkgs.follows = "nixpkgs";
     nix-homebrew.url = "github:zhaofengli-wip/nix-homebrew";
@@ -18,12 +19,19 @@
       self,
       nix-darwin,
       nixpkgs,
+      nixpkgs-stable,
       nix-homebrew,
       home-manager,
       zig-overlay,
       rust-overlay,
     }:
     let
+      # Prepare stable packages
+      stablePkgs = import nixpkgs-stable {
+        system = "aarch64-darwin";
+        config = {allowUnfree = true;};
+      };
+
       configuration =
         { pkgs, ... }:
         {
@@ -80,6 +88,7 @@
     in
     {
       darwinConfigurations."mbp" = nix-darwin.lib.darwinSystem {
+        specialArgs = { inherit stablePkgs; }; # this will make the new pkgs available to everything in the config
         modules = [
           (
             { pkgs, ... }:

--- a/modules/home-manager/bat.nix
+++ b/modules/home-manager/bat.nix
@@ -1,8 +1,9 @@
-{ pkgs, ... }:
+{ pkgs, stablePkgs, ... }:
 
 {
   programs.bat = {
     enable = true;
+    package = stablePkgs.bat; # import and swap the source
     config = {
       style = "header,header-filesize";
       theme = "ansi";


### PR DESCRIPTION
Added a stable nixpkgs as a secondary package source.  Bat was also moved over to this as a workaround for the broken upstream they currently have.